### PR TITLE
Upgrade bl to version 1.2.3 or later

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2194,12 +2194,25 @@
       "optional": true
     },
     "bl": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-      "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
+      "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
       "requires": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "block-stream": {
@@ -9933,6 +9946,17 @@
         "readable-stream": "^2.3.0",
         "to-buffer": "^1.1.1",
         "xtend": "^4.0.0"
+      },
+      "dependencies": {
+        "bl": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
+          "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
+          "requires": {
+            "readable-stream": "^2.3.5",
+            "safe-buffer": "^5.1.1"
+          }
+        }
       }
     },
     "terminal-link": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "azure-devops-extension-api": "~1.157.0",
     "azure-devops-extension-sdk": "~2.0.11",
     "azure-devops-ui": "~2.164.0",
+    "bl": ">=1.2.3",
     "eslint": "^7.0.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
@@ -43,6 +44,7 @@
   },
   "devDependencies": {
     "base64-inline-loader": "^1.1.1",
+    "bl": ">=1.2.3",
     "copy-webpack-plugin": "^6.0.3",
     "css-loader": "~1.0.0",
     "file-loader": "~2.0.0",


### PR DESCRIPTION
Based on GitHub recommendation:

Remediation
Upgrade bl to version 1.2.3 or later. For example:

"dependencies": {
  "bl": ">=1.2.3"
}
or…
"devDependencies": {
  "bl": ">=1.2.3"
}