### PR TITLE
Updates to logging and fix for using codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
 		"dbaeumer.vscode-eslint",
 		"ms-vscode.vscode-typescript-tslint-plugin",
 		"DavidAnson.vscode-markdownlint"
-	]
+	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
@@ -23,5 +23,5 @@
 	// "postCreateCommand": "yarn install",
 
 	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
-	// "remoteUser": "node"
+	"remoteUser": "node"
 }

--- a/azure-devops-extension.json
+++ b/azure-devops-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "azure-dev-ops-react-ui-unit-testing",
     "publisher": "nonexistingpublisher",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "name": "Azure DevOps ReactUI Testing",
     "description": "Showcasing Azure DevOps React based UI Extension unit testing for an advanced example.",
     "categories": [

--- a/src/MultiIdentityPicker/MultiIdentityPicker.tsx
+++ b/src/MultiIdentityPicker/MultiIdentityPicker.tsx
@@ -83,7 +83,8 @@ export class MultiIdentityPicker extends React.Component<{}, MultiIdentityPicker
           // Init Logger
           const instrumentationKey = (SDK.getConfiguration().witInputs.AppInsightsInstrumentationKey as string);
           const maxLogLevel = (SDK.getConfiguration().witInputs.LoggingLevel as SeverityLevel);
-          this.logger = new Logger(this.constructor.name, instrumentationKey, maxLogLevel);
+          // this.constructor.name will output useless information after minified 
+          this.logger = new Logger('MultiIdentityPicker', instrumentationKey, maxLogLevel);
           this.logger.startTracking('Initialization');
           this.logger.logTrace(`Logger Initialized with logLevel ${maxLogLevel}`, SeverityLevel.Verbose);
 

--- a/src/MultiIdentityPicker/MultiIdentityPicker.tsx
+++ b/src/MultiIdentityPicker/MultiIdentityPicker.tsx
@@ -83,7 +83,7 @@ export class MultiIdentityPicker extends React.Component<{}, MultiIdentityPicker
           // Init Logger
           const instrumentationKey = (SDK.getConfiguration().witInputs.AppInsightsInstrumentationKey as string);
           const maxLogLevel = (SDK.getConfiguration().witInputs.LoggingLevel as SeverityLevel);
-          // this.constructor.name will output useless information after minified 
+          // this.constructor.name will output useless information after minified
           this.logger = new Logger('MultiIdentityPicker', instrumentationKey, maxLogLevel);
           this.logger.startTracking('Initialization');
           this.logger.logTrace(`Logger Initialized with logLevel ${maxLogLevel}`, SeverityLevel.Verbose);

--- a/src/VersionedItemsTable/VersionedItemsTable.tsx
+++ b/src/VersionedItemsTable/VersionedItemsTable.tsx
@@ -107,7 +107,8 @@ export class VersionedItemsTable extends React.Component<{}> {
             // Init Logger
             const instrumentationKey = (SDK.getConfiguration().witInputs.AppInsightsInstrumentationKey as string);
             const maxLogLevel = (SDK.getConfiguration().witInputs.LoggingLevel as SeverityLevel);
-            this.logger = new Logger(this.constructor.name, instrumentationKey, maxLogLevel);
+            // this.constructor.name will output useless information after minified 
+            this.logger = new Logger('VersionedItemsTable', instrumentationKey, maxLogLevel);
             this.logger.startTracking('Initialization');
             this.logger.logTrace(`Logger Initialized with logLevel ${maxLogLevel}`, SeverityLevel.Verbose);
 

--- a/src/VersionedItemsTable/VersionedItemsTable.tsx
+++ b/src/VersionedItemsTable/VersionedItemsTable.tsx
@@ -107,7 +107,7 @@ export class VersionedItemsTable extends React.Component<{}> {
             // Init Logger
             const instrumentationKey = (SDK.getConfiguration().witInputs.AppInsightsInstrumentationKey as string);
             const maxLogLevel = (SDK.getConfiguration().witInputs.LoggingLevel as SeverityLevel);
-            // this.constructor.name will output useless information after minified 
+            // this.constructor.name will output useless information after minified
             this.logger = new Logger('VersionedItemsTable', instrumentationKey, maxLogLevel);
             this.logger.startTracking('Initialization');
             this.logger.logTrace(`Logger Initialized with logLevel ${maxLogLevel}`, SeverityLevel.Verbose);


### PR DESCRIPTION
- [X] Handing controlname as string towards logger instead of `this.constructor.name`
- [X] Switch devcontainer from root to non-root user `node`