### PR TITLE
Add content write permission to auto version increment workflow

### DIFF
--- a/.github/workflows/auto-increase-version-number.yml
+++ b/.github/workflows/auto-increase-version-number.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: write
+
 jobs:
   incversion:
     name: Increment Version

--- a/azure-devops-extension.json
+++ b/azure-devops-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "azure-dev-ops-react-ui-unit-testing",
     "publisher": "nonexistingpublisher",
-    "version": "0.1.17",
+    "version": "0.1.18",
     "name": "Azure DevOps ReactUI Testing",
     "description": "Showcasing Azure DevOps React based UI Extension unit testing for an advanced example.",
     "categories": [


### PR DESCRIPTION
With this Dependabot PRs should be allowed to correctly execute the auto-version-increment workflow